### PR TITLE
Fix URL in 02_installation.md

### DIFF
--- a/src/en/02_installation.md
+++ b/src/en/02_installation.md
@@ -14,7 +14,7 @@ Both application and server can be installed on the same machine.
 #### OmniDB Application
 
 In order to run OmniDB app, you don't need to install any additional piece of
-software. Just head to [omnidb.org](omnidb.org) and download the latest package
+software. Just head to [omnidb.org](https://omnidb.org/) and download the latest package
 for your specific operating system and architecture:
 
 - Linux 32 bits / 64 bits


### PR DESCRIPTION
Fix link to OmniDB website. Link at https://omnidb.org/en/documentation-en/installation currently directs to https://omnidb.org/omnidb.org which gives a 404.