### PR TITLE
Ctrl-Space does not work on Mac

### DIFF
--- a/src/en/07_writing_sql_queries.md
+++ b/src/en/07_writing_sql_queries.md
@@ -65,7 +65,8 @@ the `omnidb.log` file too.
 The SQL editor has a feature that helps a lot when creating new queries: SQL
 code completion. With this feature it is possible to autocomplete columns
 contained in a table referenced by an alias. To open the autocomplete interface
-you just have to type the alias, the character `.` and then hit `Ctrl-Space`:
+you just have to type the alias, the character `.` and then hit `Ctrl-Space` 
+(on Mac, hit `Shift-Space`):
 
 ![](https://raw.githubusercontent.com/OmniDB/doc/master/img/image_050.png)
 


### PR DESCRIPTION
The user should be informed that the default shortcut for Autocomplete, on Mac, is Shift-Space